### PR TITLE
Avoid wrong detection of the pattern in script file

### DIFF
--- a/Scripts/usage_description_check.swift
+++ b/Scripts/usage_description_check.swift
@@ -15,6 +15,12 @@ guard let productSettingsPathRawValue = getenv("PRODUCT_SETTINGS_PATH"),
         exit(1)
 }
 
+// Get script path
+guard let scriptPath = CommandLine.arguments.first else {
+    exit(1)
+}
+let scriptURL = URL(fileURLWithPath: scriptPath)
+
 // Get Swift file URLs
 guard let enumerator = FileManager.default.enumerator(at: projectURL, includingPropertiesForKeys: nil) else {
     exit(1)
@@ -22,6 +28,7 @@ guard let enumerator = FileManager.default.enumerator(at: projectURL, includingP
 var swiftFileURLs = enumerator.allObjects
     .compactMap { $0 as? URL }
     .filter { $0.pathExtension == "swift" }
+    .filter { $0 != scriptURL }
 
 // Get all keys for used patterns
 let patterns = ["EKEventStore": "NSCalendarsUsageDescription"]


### PR DESCRIPTION
Because `usage_description_check.swift` file contains the pattern in the `patterns` dictionary, must be excluded in order to avoid wrong detection of the pattern.